### PR TITLE
Tactical fix for single logout for IPrincipal implementations

### DIFF
--- a/Sustainsys.Saml2.Owin/OwinContextExtensions.cs
+++ b/Sustainsys.Saml2.Owin/OwinContextExtensions.cs
@@ -37,6 +37,7 @@ namespace Sustainsys.Saml2.Owin
                 applicationRootPath = "/";
             }
 
+            var user = context.Request.User as ClaimsPrincipal ?? ClaimsPrincipal.Current;
             return new HttpRequestData(
                 context.Request.Method,
                 context.Request.Uri,
@@ -44,7 +45,7 @@ namespace Sustainsys.Saml2.Owin
                 formData?.Select(f => new KeyValuePair<string, IEnumerable<string>>(f.Key, f.Value)),
                 cookieName => cookieManager.GetRequestCookie(context, cookieName),
                 cookieDecryptor,
-                context.Request.User as ClaimsPrincipal);
+                user);
         }
     }
 }


### PR DESCRIPTION
Tactical fix to cater for situations in which the current user correctly implements `IPrincipal` but is not an instance of `ClaimsPrincipal` itself, thereby breaking single logout functionality.